### PR TITLE
Androidx-navigation-compose migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,30 +5,39 @@
 </div>
 
 # Jetpack Compose Android template
+
 To create you own repo, click on:
 
 [![Use this template](https://user-images.githubusercontent.com/38083522/226207439-1195c8c4-e3e2-4db0-8f39-7277b08872be.png)](https://github.com/seve-andre/jetpack-compose-template/generate)
 
 > [!IMPORTANT]
-> [Here](https://github.com/seve-andre/jetpack-compose-template/wiki#instructions) you can find detailed instructions on how to turn the template into your own app
+> [Here](https://github.com/seve-andre/jetpack-compose-template/wiki#instructions) you can find
+> detailed instructions on how to turn the template into your own app
 
 ## What does it use?
+
 - [Kotlin](https://kotlinlang.org/) as main language
 - [Jetpack Compose](https://developer.android.com/jetpack/compose) as modern toolkit for native UI
-- [Material 3 components for Jetpack Compose](https://developer.android.com/reference/kotlin/androidx/compose/material3/package-summary#top-level-functions) to build UI faster
+- [Material 3 components for Jetpack Compose](https://developer.android.com/reference/kotlin/androidx/compose/material3/package-summary#top-level-functions)
+  to build UI faster
 - [Room](https://developer.android.com/training/data-storage/room) as local persistent DB
 - [Retrofit+OkHttp](https://square.github.io/retrofit/): for api calls
-- [Proto Datastore](https://developer.android.com/topic/libraries/architecture/datastore?gclid=CjwKCAjwkYGVBhArEiwA4sZLuMMCRUnWZzzy-AwDePYTUTn3gO6-rrT8jGo7D-H2vztegIJ-zEsb8hoCtI8QAvD_BwE&gclsrc=aw.ds) as typesafe data storage solution with protocol buffers support
-- [Dagger Hilt](https://developer.android.com/training/dependency-injection/hilt-android) for Dependency Injection
+- [Proto Datastore](https://developer.android.com/topic/libraries/architecture/datastore?gclid=CjwKCAjwkYGVBhArEiwA4sZLuMMCRUnWZzzy-AwDePYTUTn3gO6-rrT8jGo7D-H2vztegIJ-zEsb8hoCtI8QAvD_BwE&gclsrc=aw.ds)
+  as typesafe data storage solution with protocol buffers support
+- [Dagger Hilt](https://developer.android.com/training/dependency-injection/hilt-android) for
+  Dependency Injection
 - [Detekt](https://detekt.dev/) for static code analysis and formatting
 - [Timber](https://github.com/JakeWharton/timber) for logging
-- [Eva icons](https://github.com/DevSrSouza/compose-icons/blob/master/eva-icons/DOCUMENTATION.md) for the icons to use throughout the whole app
+- [Eva icons](https://github.com/DevSrSouza/compose-icons/blob/master/eva-icons/DOCUMENTATION.md)
+  for the icons to use throughout the whole app
 - [Coil](https://coil-kt.github.io/coil/compose/) for image loading backed by Kotlin coroutines
-- [Splashscreen API](https://developer.android.com/develop/ui/views/launch/splash-screen) to display a splashscreen at app launch
-- [Per-app language preferences](https://developer.android.com/guide/topics/resources/app-languages) to use a language inside the app that is different from the system language
-- [Compose Destinations](https://composedestinations.rafaelcosta.xyz/) for easier app navigation
+- [Splashscreen API](https://developer.android.com/develop/ui/views/launch/splash-screen) to display
+  a splashscreen at app launch
+- [Per-app language preferences](https://developer.android.com/guide/topics/resources/app-languages)
+  to use a language inside the app that is different from the system language
 
 ## What does it offer?
+
 - ⚫ dark theme support
 - 🇬🇧 🇮🇹 in-app language preference
 - 🔒 encrypted datastore
@@ -36,6 +45,7 @@ To create you own repo, click on:
 - 🔧 custom snackbars
 
 ## Screenshots
+
 <details>
   <summary><strong>Light/dark theme</strong></summary>
   <img src="./screenshots/home-light.png" alt="Light theme home screen screenshot" title="Home light" height="500" />
@@ -49,6 +59,7 @@ To create you own repo, click on:
 </details>
 
 ### Inspo
+
 - [version catalog](https://github.com/seve-andre/jetpack-compose-template/blob/main/gradle/libs.versions.toml): [see inspo](https://developer.android.com/build/migrate-to-catalogs)
 - [Result](https://github.com/seve-andre/jetpack-compose-template/blob/main/app/src/main/kotlin/com/mitch/appname/util/Result.kt): [see inspo](https://github.com/android/nowinandroid/blob/607c24e7f7399942e278af663ea4ad350e5bbc3a/core/common/src/main/java/com/google/samples/apps/nowinandroid/core/result/Result.kt)
 - [AppState](https://github.com/seve-andre/jetpack-compose-template/blob/main/app/src/main/kotlin/com/mitch/appname/ui/AppState.kt): [see inspo](https://github.com/android/nowinandroid/blob/607c24e7f7399942e278af663ea4ad350e5bbc3a/app/src/main/java/com/google/samples/apps/nowinandroid/ui/NiaAppState.kt)
@@ -56,4 +67,5 @@ To create you own repo, click on:
 - [ConnectivityManagerNetworkMonitor](https://github.com/seve-andre/jetpack-compose-template/blob/main/app/src/main/kotlin/com/mitch/appname/util/network/ConnectivityManagerNetworkMonitor.kt): [see inspo](https://github.com/android/nowinandroid/blob/11fbf53f12898b6ee7c55dda69716fa3600e7317/core/data/src/main/java/com/google/samples/apps/nowinandroid/core/data/util/ConnectivityManagerNetworkMonitor.kt)
 
 > [!NOTE]
-> Feel free to contribute or reach out to me at [my email](mailto:andrea.severi.dev@gmail.com?subject=[GitHub]%20Jetpack%20Compose%20Android%20Template)
+> Feel free to contribute or reach out to me
+> at [my email](mailto:andrea.severi.dev@gmail.com?subject=[GitHub]%20Jetpack%20Compose%20Android%20Template)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -100,10 +100,6 @@ kotlin {
     }
 }
 
-ksp {
-    arg("compose-destinations.codeGenPackageName", "$packageName.navigation")
-}
-
 detekt {
     config.setFrom("$rootDir/config/detekt/detekt.yml")
     baseline = file("$rootDir/config/detekt/baseline.xml")
@@ -128,6 +124,7 @@ dependencies {
     implementation(libs.kotlin.stdlib)
     implementation(libs.kotlinx.immutableCollections)
     implementation(libs.kotlinx.datetime)
+    implementation(libs.kotlinx.serialization.json)
     implementation(libs.kotlinx.serialization.protobuf)
     implementation(libs.kotlinx.coroutines.android)
     testImplementation(libs.kotlinx.coroutines.test)
@@ -158,8 +155,7 @@ dependencies {
     implementation(libs.skeletonLoader)
 
     // Navigation
-    implementation(libs.compose.destinations.core)
-    ksp(libs.compose.destinations.ksp)
+    implementation(libs.compose.navigation)
 
     // Dependency Injection
     implementation(libs.hilt.android)

--- a/app/src/main/kotlin/com/mitch/appname/MainActivity.kt
+++ b/app/src/main/kotlin/com/mitch/appname/MainActivity.kt
@@ -30,7 +30,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.SwipeToDismissBox
 import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.Text
@@ -50,7 +49,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.mitch.appname.domain.models.AppTheme
-import com.mitch.appname.navigation.NavGraphs
 import com.mitch.appname.ui.AppState
 import com.mitch.appname.ui.designsystem.AppMaterialTheme
 import com.mitch.appname.ui.designsystem.components.snackbars.AppSnackbar
@@ -59,9 +57,11 @@ import com.mitch.appname.ui.designsystem.components.snackbars.AppSnackbarType
 import com.mitch.appname.ui.designsystem.components.snackbars.AppSnackbarVisuals
 import com.mitch.appname.ui.designsystem.theme.custom.LocalPadding
 import com.mitch.appname.ui.designsystem.theme.custom.padding
+import com.mitch.appname.ui.navigation.AppNavHost
+import com.mitch.appname.ui.navigation.AppNavigation
+import com.mitch.appname.ui.navigation.AppStartDestination
 import com.mitch.appname.ui.rememberAppState
 import com.mitch.appname.util.network.NetworkMonitor
-import com.ramcosta.composedestinations.DestinationsNavHost
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.onEach
@@ -132,18 +132,10 @@ class MainActivity : AppCompatActivity() {
                                     )
                                 )
                         ) {
-                            val onShowSnackbar: suspend (AppSnackbarVisuals) -> SnackbarResult = {
-                                appState.snackbarHostState.showSnackbar(it)
-                            }
-
-                            DestinationsNavHost(
-                                navGraph = NavGraphs.root,
-                                navController = appState.navController
-
-                                // to provide snackbar lambda to invoke in "@Composable"s
-                                /*dependenciesContainerBuilder = {
-                                    dependency(HomeRouteDestination) { onShowSnackbar }
-                                }*/
+                            AppNavHost(
+                                navController = appState.navController,
+                                startDestination = AppStartDestination.Screen(AppNavigation.Screen.Home),
+                                onShowSnackbar = { appState.snackbarHostState.showSnackbar(it) }
                             )
                         }
                     }

--- a/app/src/main/kotlin/com/mitch/appname/MainActivityViewModel.kt
+++ b/app/src/main/kotlin/com/mitch/appname/MainActivityViewModel.kt
@@ -2,8 +2,8 @@ package com.mitch.appname
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.mitch.appname.domain.models.AppTheme
 import com.mitch.appname.data.settings.UserSettingsRepository
+import com.mitch.appname.domain.models.AppTheme
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.map

--- a/app/src/main/kotlin/com/mitch/appname/core/db/AppDatabase.kt
+++ b/app/src/main/kotlin/com/mitch/appname/core/db/AppDatabase.kt
@@ -1,6 +1,5 @@
 package com.mitch.appname.core.db
 
-import androidx.room.Database
 import androidx.room.RoomDatabase
 
 // see at https://developer.android.com/training/data-storage/room#database

--- a/app/src/main/kotlin/com/mitch/appname/data/settings/UserSettingsRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/mitch/appname/data/settings/UserSettingsRepositoryImpl.kt
@@ -1,8 +1,8 @@
 package com.mitch.appname.data.settings
 
 import com.mitch.appname.data.language.LanguageLocalDataSource
-import com.mitch.appname.data.userprefs.UserPreferencesLocalDataSource
 import com.mitch.appname.data.language.toAppLanguage
+import com.mitch.appname.data.userprefs.UserPreferencesLocalDataSource
 import com.mitch.appname.domain.models.AppLanguage
 import com.mitch.appname.domain.models.AppTheme
 import kotlinx.coroutines.flow.Flow

--- a/app/src/main/kotlin/com/mitch/appname/di/BindModule.kt
+++ b/app/src/main/kotlin/com/mitch/appname/di/BindModule.kt
@@ -1,7 +1,7 @@
 package com.mitch.appname.di
 
-import com.mitch.appname.data.settings.UserSettingsRepositoryImpl
 import com.mitch.appname.data.settings.UserSettingsRepository
+import com.mitch.appname.data.settings.UserSettingsRepositoryImpl
 import com.mitch.appname.util.network.ConnectivityManagerNetworkMonitor
 import com.mitch.appname.util.network.NetworkMonitor
 import dagger.Binds

--- a/app/src/main/kotlin/com/mitch/appname/ui/AppState.kt
+++ b/app/src/main/kotlin/com/mitch/appname/ui/AppState.kt
@@ -5,15 +5,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.lifecycle.Lifecycle
-import androidx.navigation.NavController
+import androidx.navigation.NavDestination
 import androidx.navigation.NavHostController
+import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
-import com.mitch.appname.navigation.NavGraphs
-import com.mitch.appname.navigation.appCurrentDestinationAsState
-import com.mitch.appname.navigation.appDestination
-import com.mitch.appname.navigation.destinations.Destination
-import com.mitch.appname.navigation.startAppDestination
 import com.mitch.appname.util.network.NetworkMonitor
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.SharingStarted
@@ -45,15 +40,8 @@ class AppState(
      *
      * Starting destination: search for `@RootNavGraph(start = true)`
      */
-    val currentDestination: Destination
-        @Composable get() = navController.appCurrentDestinationAsState().value
-            ?: NavGraphs.root.startAppDestination
-
-    /**
-     * App's previous destination if set, otherwise null
-     */
-    val prevDestination: Destination?
-        @Composable get() = navController.previousBackStackEntry?.appDestination()
+    val currentDestination: NavDestination?
+        @Composable get() = navController.currentBackStackEntryAsState().value?.destination
 
     /**
      * Manages app connectivity status
@@ -65,15 +53,4 @@ class AppState(
             started = SharingStarted.WhileSubscribed(5_000),
             initialValue = false
         )
-}
-
-/**
- * If the lifecycle is not resumed it means this NavBackStackEntry already processed a nav event.
- *
- * This is used to de-duplicate navigation events.
- */
-fun NavController.navigateToPreviousScreen() {
-    if (this.currentBackStackEntry?.lifecycle?.currentState == Lifecycle.State.RESUMED) {
-        this.popBackStack()
-    }
 }

--- a/app/src/main/kotlin/com/mitch/appname/ui/navigation/AppNavHost.kt
+++ b/app/src/main/kotlin/com/mitch/appname/ui/navigation/AppNavHost.kt
@@ -1,0 +1,80 @@
+package com.mitch.appname.ui.navigation
+
+import androidx.compose.material3.SnackbarResult
+import androidx.compose.runtime.Composable
+import androidx.lifecycle.Lifecycle
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavController
+import androidx.navigation.NavHostController
+import androidx.navigation.NavOptions
+import androidx.navigation.Navigator
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import com.mitch.appname.ui.designsystem.components.snackbars.AppSnackbarVisuals
+import com.mitch.appname.ui.navigation.AppNavigation.Graph
+import com.mitch.appname.ui.navigation.AppNavigation.Screen
+import com.mitch.appname.ui.screens.home.HomeRoute
+
+@Composable
+fun AppNavHost(
+    navController: NavHostController,
+    startDestination: AppStartDestination,
+    onShowSnackbar: suspend (AppSnackbarVisuals) -> SnackbarResult
+) {
+    NavHost(
+        navController = navController,
+        startDestination = when (startDestination) {
+            is AppStartDestination.Screen -> startDestination.screen
+            is AppStartDestination.Graph -> startDestination.graph
+        }
+    ) {
+        composable<Screen.Home> { HomeRoute() }
+    }
+}
+
+sealed interface AppStartDestination {
+    data class Screen(val screen: AppNavigation.Screen) : AppStartDestination
+    data class Graph(val graph: AppNavigation.Graph) : AppStartDestination
+}
+
+/**
+ * Consider using this wrapper to avoid navigating to the same destination twice.
+ */
+fun NavController.navigateTo(
+    screen: Screen,
+    navOptions: NavOptions? = null,
+    navigatorExtras: Navigator.Extras? = null
+) {
+    if (this.currentBackStackEntry.lifecycleIsResumed()) {
+        this.navigate(screen, navOptions, navigatorExtras)
+    }
+}
+
+fun NavController.navigateTo(
+    graph: Graph,
+    navOptions: NavOptions? = null,
+    navigatorExtras: Navigator.Extras? = null
+) {
+    if (this.currentBackStackEntry.lifecycleIsResumed()) {
+        this.navigate(graph, navOptions, navigatorExtras)
+    }
+}
+
+/**
+ * If the lifecycle is not resumed it means this NavBackStackEntry already processed a nav event.
+ *
+ * This is used to de-duplicate navigation events.
+ */
+fun NavController.navigateToPreviousScreen() {
+    if (this.currentBackStackEntry.lifecycleIsResumed()) {
+        this.popBackStack()
+    }
+}
+
+/**
+ * Sometimes clicking twice on a button causes navigating twice to the same destination, 'cause of animations.
+ * Consider wrapping each navigate call with this.
+ */
+fun NavBackStackEntry?.lifecycleIsResumed(): Boolean {
+    return this?.lifecycle?.currentState == Lifecycle.State.RESUMED
+}

--- a/app/src/main/kotlin/com/mitch/appname/ui/navigation/AppNavigation.kt
+++ b/app/src/main/kotlin/com/mitch/appname/ui/navigation/AppNavigation.kt
@@ -1,0 +1,16 @@
+package com.mitch.appname.ui.navigation
+
+import kotlinx.serialization.Serializable
+
+object AppNavigation {
+
+    sealed interface Screen {
+        @Serializable
+        data object Home : Screen
+
+        @Serializable
+        data class Profile(val id: Int) : Screen
+    }
+
+    sealed interface Graph
+}

--- a/app/src/main/kotlin/com/mitch/appname/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/mitch/appname/ui/screens/home/HomeScreen.kt
@@ -21,11 +21,7 @@ import com.mitch.appname.domain.models.AppTheme
 import com.mitch.appname.ui.designsystem.components.loading.LoadingScreen
 import com.mitch.appname.ui.screens.home.components.LanguagePickerDialog
 import com.mitch.appname.ui.screens.home.components.ThemePickerDialog
-import com.ramcosta.composedestinations.annotation.Destination
-import com.ramcosta.composedestinations.annotation.RootNavGraph
 
-@RootNavGraph(start = true)
-@Destination
 @Composable
 fun HomeRoute(
     viewModel: HomeViewModel = hiltViewModel()

--- a/app/src/main/kotlin/com/mitch/appname/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/mitch/appname/ui/screens/home/HomeViewModel.kt
@@ -2,9 +2,9 @@ package com.mitch.appname.ui.screens.home
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.mitch.appname.data.settings.UserSettingsRepository
 import com.mitch.appname.domain.models.AppLanguage
 import com.mitch.appname.domain.models.AppTheme
-import com.mitch.appname.data.settings.UserSettingsRepository
 import com.mitch.appname.util.Result
 import com.mitch.appname.util.asResult
 import dagger.hilt.android.lifecycle.HiltViewModel

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -1,10 +1,8 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" ?>
 <SmellBaseline>
-  <ManuallySuppressedIssues>
-    <ID>CompositionLocalAllowlist:ExtendedColorScheme.kt$LocalExtendedColorScheme</ID>
-    <ID>CompositionLocalAllowlist:Padding.kt$LocalPadding</ID>
-  </ManuallySuppressedIssues>
-  <CurrentIssues>
-    <ID>UnusedPrivateProperty:MainActivity.kt$MainActivity$val onShowSnackbar: suspend (AppSnackbarVisuals) -> SnackbarResult = { appState.snackbarHostState.showSnackbar(it) }</ID>
-  </CurrentIssues>
+    <ManuallySuppressedIssues>
+        <ID>CompositionLocalAllowlist:ExtendedColorScheme.kt$LocalExtendedColorScheme</ID>
+        <ID>CompositionLocalAllowlist:Padding.kt$LocalPadding</ID>
+        <ID>UnusedParameter:AppNavHost.kt$onShowSnackbar: suspend (AppSnackbarVisuals) -&gt; SnackbarResult</ID>
+    </ManuallySuppressedIssues>
 </SmellBaseline>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 kotlin = "1.9.21" # check also ksp
 kotlinx-immutableCollections = "0.3.7"
 kotlinx-datetime = "0.5.0"
-kotlinx-serialization-protobuf = "1.6.2"
+kotlinx-serialization = "1.6.2"
 kotlinx-coroutines = "1.7.3"
 
 # UI
@@ -20,7 +20,7 @@ appcompat = "1.6.1"
 eygraber-placeholder-m3 = "1.0.7"
 
 # Navigation
-compose-destinations = "1.9.62" # check compose version
+compose-navigation = "2.8.0-alpha08"
 
 # Dependency Injection
 hilt = "2.49"
@@ -75,7 +75,8 @@ secrets = "2.0.1"
 kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib-jdk8", version.ref = "kotlin" }
 kotlinx-immutableCollections = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinx-immutableCollections" }
 kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version.ref = "kotlinx-datetime" }
-kotlinx-serialization-protobuf = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-protobuf", version.ref = "kotlinx-serialization-protobuf" }
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
+kotlinx-serialization-protobuf = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-protobuf", version.ref = "kotlinx-serialization" }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 
@@ -110,8 +111,7 @@ appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "a
 skeletonLoader = { group = "com.eygraber", name = "compose-placeholder-material3", version.ref = "eygraber-placeholder-m3" }
 
 # Navigation
-compose-destinations-core = { group = "io.github.raamcosta.compose-destinations", name = "core", version.ref = "compose-destinations" }
-compose-destinations-ksp = { group = "io.github.raamcosta.compose-destinations", name = "ksp", version.ref = "compose-destinations" }
+compose-navigation = { group = "androidx.navigation", name = "navigation-compose", version.ref = "compose-navigation" }
 
 # Dependency Injection
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }


### PR DESCRIPTION
Since `androidx.navigation:navigation-compose` v2.8.0-alpha08, typesafe navigation has been implemented via kotlinx serialization. The decision is to migrate to it and drop [`raamcosta/compose-destinations`](https://github.com/raamcosta/compose-destinations) to follow Google's recommendations.