### PR TITLE
Add resumed check for navigation

### DIFF
--- a/app/src/main/kotlin/com/mitch/template/ui/navigation/TemplateNavHost.kt
+++ b/app/src/main/kotlin/com/mitch/template/ui/navigation/TemplateNavHost.kt
@@ -2,6 +2,7 @@ package com.mitch.template.ui.navigation
 
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.runtime.Composable
+import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.navigation.NavController
 import androidx.navigation.NavHostController
 import androidx.navigation.NavOptions
@@ -26,7 +27,9 @@ fun TemplateNavHost(
             is TemplateStartDestination.Graph -> startDestination.graph
         }
     ) {
-        composable<Screen.Home> { HomeRoute() }
+        composable<Screen.Home> {
+            HomeRoute()
+        }
     }
 }
 
@@ -35,18 +38,22 @@ sealed interface TemplateStartDestination {
     data class Graph(val graph: TemplateDestinations.Graph) : TemplateStartDestination
 }
 
+// dropUnlessResumed is used to avoid navigating multiple times to the same destination or
+// popping the backstack when the destination is already on top.
+@Composable
 fun NavController.navigateTo(
     screen: Screen,
     navOptions: NavOptions? = null,
     navigatorExtras: Navigator.Extras? = null
-) {
+): () -> Unit = dropUnlessResumed {
     this.navigate(screen, navOptions, navigatorExtras)
 }
 
+@Composable
 fun NavController.navigateTo(
     graph: Graph,
     navOptions: NavOptions? = null,
     navigatorExtras: Navigator.Extras? = null
-) {
+): () -> Unit = dropUnlessResumed {
     this.navigate(graph, navOptions, navigatorExtras)
 }


### PR DESCRIPTION
Since `androidx.lifecycle:lifecycle-*:2.8.0`, `dropUnlessResumed` and `dropUnlessStarted` APIs are available. These are super handy when using `androidx.navigation:navigation-compose`.  By default, navigating to a screen includes animations, which can cause weird behavior like navigating twice to the same route or popping the back stack multiple times if the destination is already on top. Previously, the solution to this issue was outlined in android/compose-samples#456.

```kotlin
// BEFORE
private fun NavBackStackEntry.lifecycleIsResumed() = this.lifecycle.currentState == Lifecycle.State.RESUMED
val onNavigateToSettings = {
    if (navBackStackEntry.lifecycleIsResumed()) navController.navigateToSettingsScreen()
}

// AFTER
val onNavigateToSettings  = dropUnlessResumed { navController.navigateToSettingsScreen() }
```