### PR TITLE
Remove `osipxd` encrypted datastore dep

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -176,7 +176,6 @@ dependencies {
 
     // Datastore (previously SharedPreferences)
     implementation(libs.datastore.core)
-    implementation(libs.encryptedDatastore)
 
     // Logging
     implementation(libs.timber)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,6 @@ room = "2.6.1"
 
 # Datastore
 datastore = "1.1.1"
-encryptedDatastore = "1.0.0-beta01"
 
 # Logging
 timber = "5.0.1"
@@ -121,7 +120,6 @@ room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "
 
 # Datastore
 datastore-core = { group = "androidx.datastore", name = "datastore", version.ref = "datastore" }
-encryptedDatastore = { group = "io.github.osipxd", name = "encrypted-datastore", version.ref = "encryptedDatastore" }
 
 # Logging
 timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "timber" }


### PR DESCRIPTION
Removed the dependency in favor of own KeyStore manager implementation. An example can be found [here](https://github.com/seve-andre/jetpack-compose-template/wiki/Features-implementation).