### PR TITLE
Apply user dark mode preference to splashscreen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
         tools:targetApi="33">
         <activity
             android:name=".MainActivity"
-            android:configChanges="locale|layoutDirection"
+            android:configChanges="locale|layoutDirection|uiMode"
             android:exported="true"
             android:windowSoftInputMode="adjustResize">
             <intent-filter>


### PR DESCRIPTION
This PR aims to align the splash screen with the user's dark mode preference. However, this solution only works for API >= 31 (see screen recordings below).

<details>
  <summary><strong>API >= 31</strong></summary>

  [API-32.webm](https://github.com/user-attachments/assets/79349600-ccc2-4b67-90a5-864087528f12)
</details>

<details>
  <summary><strong>API <= 30</strong></summary>

  [API-30.mov](https://github.com/user-attachments/assets/8151c6e0-1a60-4356-9a0e-b847961a1ee5)
</details>

