### PR TITLE
Replace deprecated `stabilityConfigurationFile`

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -175,8 +175,9 @@ kotlin {
 
 composeCompiler {
     reportsDestination = layout.buildDirectory.dir("compose_compiler")
-    stabilityConfigurationFile =
+    stabilityConfigurationFiles.addAll(
         rootProject.layout.projectDirectory.file("compose_compiler_config.conf")
+    )
 }
 
 detekt {


### PR DESCRIPTION
New `stabilityConfigurationFiles` API allows passing in multiple files, instead of just one.