### PR TITLE
Fallback destination for currentDestination

### DIFF
--- a/app/src/main/kotlin/com/mitch/template/MainActivity.kt
+++ b/app/src/main/kotlin/com/mitch/template/MainActivity.kt
@@ -90,7 +90,7 @@ class MainActivity : AppCompatActivity() {
                     navigationBarStyle = SystemBarStyle.auto(
                         LightScrim,
                         DarkScrim
-                    ) { themeInfo.isThemeDark },
+                    ) { themeInfo.isThemeDark }
                 )
                 setAppTheme(
                     uiModeManager = getSystemService(Context.UI_MODE_SERVICE) as UiModeManager,


### PR DESCRIPTION
Maintaining a reference to previousDestination ensures that currentDestination does not get set to null.

https://github.com/android/nowinandroid/pull/1728